### PR TITLE
[Task]: re-add `lcobucci\jwt` package requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "pimcore/pimcore": "^11.0",
         "geoip2/geoip2": "^2.9",
         "symfony/stopwatch": "^6.2",
-        "symfony/form": "^6.2"
+        "symfony/form": "^6.2",
+        "lcobucci/jwt": "^4.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.9",


### PR DESCRIPTION
It got removed https://github.com/pimcore/pimcore/pull/14856 but is in use in this bundle
https://github.com/pimcore/personalization-bundle/blob/59bcdd3f799141be9ecf735ec528371fca0fb13f/src/Targeting/Storage/Cookie/JWTCookieSaveHandler.php#L20-L26

TODO: verify if we can bump to version https://github.com/lcobucci/jwt/releases/tag/5.0.0