### PR TITLE
Fix issue with the target editable data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,6 @@
             "*": "dist"
         }
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev",
     "require": {
         "php": "~8.1.0 || ~8.2.0",
         "pimcore/pimcore": "^11.0",

--- a/src/Targeting/EventListener/Frontend/TargetingElementListener.php
+++ b/src/Targeting/EventListener/Frontend/TargetingElementListener.php
@@ -50,7 +50,7 @@ class TargetingElementListener implements EventSubscriberInterface, LoggerAwareI
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::CONTROLLER => ['onKernelController', 30], // has to be after DocumentFallbackListener
+            KernelEvents::CONTROLLER => ['onKernelController', 29], // has to be after DocumentFallbackListener
         ];
     }
 

--- a/src/Targeting/EventListener/Frontend/TargetingElementListener.php
+++ b/src/Targeting/EventListener/Frontend/TargetingElementListener.php
@@ -50,7 +50,7 @@ class TargetingElementListener implements EventSubscriberInterface, LoggerAwareI
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::CONTROLLER => ['onKernelController', 29], // has to be after DocumentFallbackListener
+            KernelEvents::CONTROLLER => ['onKernelController', 29], // has to be after DocumentFallbackListener & ElementListener
         ];
     }
 

--- a/tests/Unit/Targeting/Document/TargetGroupEditableTest.php
+++ b/tests/Unit/Targeting/Document/TargetGroupEditableTest.php
@@ -65,7 +65,7 @@ class TargetGroupEditableTest extends ModelTestCase
         //Test the value of first target group editable again
         $this->testDataHelper->assertInput($this->testPage, $targetGroupEditableName1, $targetGroup1EditableSeed);
 
-        //$this->reloadPage();
+        $this->reloadPage();
 
         // Test after reloading
         $this->testDataHelper->assertInput($this->testPage, $targetGroupEditableName1, $targetGroup1EditableSeed);


### PR DESCRIPTION
Resolves https://github.com/pimcore/personalization-bundle/issues/46


'TargetingElementListener' was extracted from the 'ElementListener' when the personalization bundle was refactored. Since both listeners had the same priority, 'ElementListener' was executing after the 'TargetingElementListener'.  But, the 'TargetingElementListener' only sets the target group id to the document. So, it should be executed after the 'ElementListener'.