### PR TITLE
Remove useless call to `$builder->getToken()` in `JWTCookieSaveHandler::createTokenBuilder()`

### DIFF
--- a/src/Targeting/Storage/Cookie/JWTCookieSaveHandler.php
+++ b/src/Targeting/Storage/Cookie/JWTCookieSaveHandler.php
@@ -133,8 +133,6 @@ class JWTCookieSaveHandler extends AbstractCookieSaveHandler
             $builder->expiresAt($expire);
         }
 
-        $builder->getToken($this->config->signer(), $this->config->signingKey());
-
         return $builder;
     }
 }


### PR DESCRIPTION
The return value of the removed line was not used, so it was useless. 

The method is creating the token builder and the calling method then gets the token from it, see: https://github.com/pimcore/personalization-bundle/blob/8e63a44eb3af6526088bbd70bd65f7beabe9b88e/src/Targeting/Storage/Cookie/JWTCookieSaveHandler.php#L101