### PR TITLE
Bump lcobucci/jwt to version 5 (#11)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "geoip2/geoip2": "^2.9",
         "symfony/stopwatch": "^6.2",
         "symfony/form": "^6.2",
-        "lcobucci/jwt": "^4.0",
+        "lcobucci/jwt": "^4.0 || ^5.0",
         "matomo/device-detector": "^6.0",
         "pimcore/newsletter-bundle": "^1.0",
         "colinmollenhour/credis": "^1.10.0",

--- a/src/Targeting/Storage/Cookie/JWTCookieSaveHandler.php
+++ b/src/Targeting/Storage/Cookie/JWTCookieSaveHandler.php
@@ -118,19 +118,18 @@ class JWTCookieSaveHandler extends AbstractCookieSaveHandler
     {
         $time = new \DateTimeImmutable();
 
-        $builder = $this->config->builder();
-        $builder
+        $builder = $this->config->builder()
             ->issuedAt($time)
             ->withClaim(self::CLAIM_TARGETING_DATA, $data);
 
         if (0 === $expire) {
-            $builder->expiresAt($time->modify('+30 minutes')); // expire in 30 min
+            $builder = $builder->expiresAt($time->modify('+30 minutes')); // expire in 30 min
         } elseif (is_int($expire) && $expire > 0) {
             $expire = new \DateTimeImmutable('@'. $expire);
-            $builder->expiresAt($expire);
+            $builder = $builder->expiresAt($expire);
         } elseif ($expire instanceof \DateTimeInterface) {
             $expire = new \DateTimeImmutable('@'. $expire->getTimestamp());
-            $builder->expiresAt($expire);
+            $builder = $builder->expiresAt($expire);
         }
 
         return $builder;


### PR DESCRIPTION
This resolves issue #11 which seems the last task for version/milestone 1.1.

That same milestone includes the PHP8.3 support. With upcoming Ubuntu 24.04 we'd really like to be ready to upgrade our clients.

As suggested by @fashxp in the issue I went with the `^4.0 || ^5.0` approach to avoid BC breaks.
I tested them on both versions in the demo project. 

Only change needed was that the builder is immutable as of 5.0. As those methods returned `$this` in 4.0, no hacks were needed to support both versions.